### PR TITLE
Improve deck cache behavior and Kafka consumer configuration

### DIFF
--- a/services/deck/src/main/java/com/tinder/deck/kafka/config/KafkaConsumerConfig.java
+++ b/services/deck/src/main/java/com/tinder/deck/kafka/config/KafkaConsumerConfig.java
@@ -56,6 +56,28 @@ public class KafkaConsumerConfig {
     }
 
     /**
+     * Consumer factory for SwipeCreatedEvent deserialization
+     */
+    @Bean
+    public ConsumerFactory<String, SwipeCreatedEvent> swipeEventConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.tinder.deck.kafka.dto");
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, SwipeCreatedEvent.class.getName());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        // Performance tuning
+        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 100);
+        props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 30000);
+        props.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 10000);
+
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    /**
      * Listener container factory with manual acknowledgment
      */
     @Bean
@@ -67,6 +89,22 @@ public class KafkaConsumerConfig {
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
 
         // Error handling
+        factory.setCommonErrorHandler(new org.springframework.kafka.listener.DefaultErrorHandler());
+
+        return factory;
+    }
+
+    /**
+     * Listener container factory for SwipeCreatedEvent with manual acknowledgment
+     */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, SwipeCreatedEvent> swipeKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, SwipeCreatedEvent> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(swipeEventConsumerFactory());
+        factory.setConcurrency(concurrency);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+
         factory.setCommonErrorHandler(new org.springframework.kafka.listener.DefaultErrorHandler());
 
         return factory;

--- a/services/deck/src/main/java/com/tinder/deck/kafka/config/KafkaConsumerConfig.java
+++ b/services/deck/src/main/java/com/tinder/deck/kafka/config/KafkaConsumerConfig.java
@@ -62,7 +62,7 @@ public class KafkaConsumerConfig {
     public ConsumerFactory<String, SwipeCreatedEvent> swipeEventConsumerFactory() {
         Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId + "-swipe");
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
         props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.tinder.deck.kafka.dto");

--- a/services/deck/src/main/java/com/tinder/deck/kafka/consumer/SwipeEventConsumer.java
+++ b/services/deck/src/main/java/com/tinder/deck/kafka/consumer/SwipeEventConsumer.java
@@ -36,7 +36,7 @@ public class SwipeEventConsumer {
     @KafkaListener(
             topics = "${kafka.topics.swipe-events}",
             groupId = "${spring.kafka.consumer.group-id}",
-            containerFactory = "kafkaListenerContainerFactory"
+            containerFactory = "swipeKafkaListenerContainerFactory"
     )
     public void consume(
             @Payload SwipeCreatedEvent event,

--- a/services/deck/src/main/java/com/tinder/deck/service/DeckCache.java
+++ b/services/deck/src/main/java/com/tinder/deck/service/DeckCache.java
@@ -29,6 +29,9 @@ public class DeckCache {
     private static String deckTsKey(UUID id)      { return "deck:build:ts:" + id; }
     private static String staleKey(UUID viewerId) { return "deck:stale:" + viewerId; }
     private static String lockKey(UUID viewerId)  { return "deck:lock:" + viewerId; }
+    // Matches only primary deck data keys of the form "deck:{uuid}" and intentionally
+    // excludes other "deck:"-prefixed keys such as "deck:build:ts:*", "deck:stale:*",
+    // and "deck:lock:*".
     private static final Pattern DECK_KEY_PATTERN = Pattern.compile("^deck:([0-9a-fA-F-]{36})$");
     private static String preferencesKey(int minAge, int maxAge, String gender) {
         return String.format("prefs:%d:%d:%s", minAge, maxAge, gender.toUpperCase());

--- a/services/deck/src/main/java/com/tinder/deck/service/DeckScheduler.java
+++ b/services/deck/src/main/java/com/tinder/deck/service/DeckScheduler.java
@@ -32,12 +32,11 @@ public class DeckScheduler {
      * - 100x fewer database queries compared to individual rebuilds
      */
 
-    // TODO adjust cron expression as needed
-    @Scheduled(cron = "0 */1 * * * *")
+    @Scheduled(cron = "${deck.scheduler.cron:0 0 * * * *}")
     public void rebuildAllDecks() {
 
-        log.info("Starting scheduled batch deck rebuild (hourly)");
-        log.info("Preferences cache enabled - efficient batch processi^ng mode");
+        log.info("Starting scheduled batch deck rebuild");
+        log.info("Preferences cache enabled - efficient batch processing mode");
 
         Flux<SharedProfileDto> activeUsers = profilesHttp.getActiveUsers();
 

--- a/services/deck/src/main/java/com/tinder/deck/service/pipeline/CandidateSearchStage.java
+++ b/services/deck/src/main/java/com/tinder/deck/service/pipeline/CandidateSearchStage.java
@@ -79,6 +79,7 @@ public class CandidateSearchStage {
                 prefs.minAge(), prefs.maxAge(), prefs.gender());
 
         return deckCache.getCandidatesByPreferences(prefs.minAge(), prefs.maxAge(), prefs.gender())
+                .take(searchLimit)
                 .collectList()
                 .flatMapMany(cachedIds ->
                         preferencesCacheHelper.fetchProfilesByIds(

--- a/services/deck/src/main/resources/application.yml
+++ b/services/deck/src/main/resources/application.yml
@@ -16,7 +16,6 @@ spring:
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
         spring.json.trusted.packages: "com.tinder.deck.kafka.dto"
-        spring.json.value.default.type: com.tinder.deck.kafka.dto.ProfileEvent
     listener:
       concurrency: 3  # Number of consumer threads
       ack-mode: manual  # Manual commit for better control
@@ -81,5 +80,4 @@ management:
     metrics:
       export:
         enabled: true
-
 


### PR DESCRIPTION
### Motivation
- Prevent incorrect deserialization of `SwipeCreatedEvent` when `ProfileEvent`-typed listener is used without type headers. 
- Ensure critical profile updates (age/location/gender) are marked stale across other users' cached decks so viewers don't see outdated candidates. 
- Make preferences cache TTL configurable and avoid returning unbounded sets from the cache which can trigger excessive profile fetches. 
- Align scheduled rebuild behavior with configuration and remove unused/duplicated cache helper code to simplify maintenance.

### Description
- Added a dedicated consumer factory and listener container for swipe events (`swipeEventConsumerFactory` and `swipeKafkaListenerContainerFactory`) and switched `SwipeEventConsumer` to `containerFactory = "swipeKafkaListenerContainerFactory"`, and removed `spring.json.value.default.type` from `application.yml` to avoid forcing a single default type.  
- Updated `ProfileEventConsumer` to remove unused preference-parsing helpers and to call `deckCache.markAsStaleForAllDecks(profileId)` on `CRITICAL_FIELDS` so affected profiles are marked stale across cached decks.  
- Extended `DeckCache` with `markAsStaleForAllDecks(UUID)`, added `DECK_KEY_PATTERN`, and made preferences cache TTL configurable via `@Value("${deck.preferences-cache-ttl-minutes:5}")` and applied that TTL in `cachePreferencesResult`.  
- Capped cache-hit candidate IDs in `CandidateSearchStage` by adding `.take(searchLimit)` before fetching profiles to avoid over-fetching, made the scheduler cron configurable via `@Scheduled(cron = "${deck.scheduler.cron:0 0 * * * *}")`, and fixed a log typo; removed several unused methods from `PreferencesCacheHelper` to reduce maintenance burden.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697745aa55a8832fbc59040a722af52f)