### PR TITLE
Add Resilience4j circuit breakers and minimal tests for profiles, swipes, Redis and Nominatim

### DIFF
--- a/services/deck/pom.xml
+++ b/services/deck/pom.xml
@@ -49,11 +49,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>

--- a/services/deck/pom.xml
+++ b/services/deck/pom.xml
@@ -49,6 +49,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
@@ -116,6 +121,18 @@
 			<version>7.4</version>
 		</dependency>
 
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-spring-boot3</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-reactor</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-bulkhead</artifactId>
+		</dependency>
 
     </dependencies>
 

--- a/services/deck/src/main/java/com/tinder/deck/adapters/ProfilesHttp.java
+++ b/services/deck/src/main/java/com/tinder/deck/adapters/ProfilesHttp.java
@@ -2,15 +2,24 @@ package com.tinder.deck.adapters;
 
 import com.tinder.deck.dto.SharedPreferencesDto;
 import com.tinder.deck.dto.SharedProfileDto;
+import io.github.resilience4j.bulkhead.SemaphoreBulkhead;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.reactor.bulkhead.operator.BulkheadOperator;
+import io.github.resilience4j.reactor.circuitbreaker.operator.CircuitBreakerOperator;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 import java.util.UUID;
 
 @Service
@@ -18,6 +27,17 @@ import java.util.UUID;
 public class ProfilesHttp {
     private static final Logger log = LoggerFactory.getLogger(ProfilesHttp.class);
     private final WebClient profilesWebClient;
+    private final CircuitBreaker profilesCircuitBreaker;
+    private final SemaphoreBulkhead profilesBulkhead;
+
+    @Value("${deck.clients.profiles.timeout-ms:1500}")
+    private long timeoutMs;
+
+    @Value("${deck.clients.profiles.retry.max-attempts:2}")
+    private int maxRetries;
+
+    @Value("${deck.clients.profiles.retry.backoff-ms:200}")
+    private long retryBackoffMs;
 
     public Flux<SharedProfileDto> searchProfiles(UUID viewerId, SharedPreferencesDto preferences, int limit) {
         // Use default preferences if null
@@ -45,6 +65,14 @@ public class ProfilesHttp {
                 })
                 .retrieve()
                 .bodyToFlux(SharedProfileDto.class)
+                .timeout(Duration.ofMillis(timeoutMs))
+                .retryWhen(buildRetry("searchProfiles"))
+                .transformDeferred(BulkheadOperator.of(profilesBulkhead))
+                .transformDeferred(CircuitBreakerOperator.of(profilesCircuitBreaker))
+                .onErrorResume(CallNotPermittedException.class, throwable -> {
+                    log.warn("Profiles circuit breaker open (searchProfiles). Returning empty result.");
+                    return Flux.empty();
+                })
                 .onErrorResume(throwable -> {
                     log.warn("Failed to call profiles service (searchProfiles). Returning empty result. Cause: {}", throwable.toString());
                     return Flux.empty();
@@ -58,6 +86,14 @@ public class ProfilesHttp {
                         .build())
                 .retrieve()
                 .bodyToFlux(SharedProfileDto.class)
+                .timeout(Duration.ofMillis(timeoutMs))
+                .retryWhen(buildRetry("getActiveUsers"))
+                .transformDeferred(BulkheadOperator.of(profilesBulkhead))
+                .transformDeferred(CircuitBreakerOperator.of(profilesCircuitBreaker))
+                .onErrorResume(CallNotPermittedException.class, throwable -> {
+                    log.warn("Profiles circuit breaker open (getActiveUsers). Returning empty result.");
+                    return Flux.empty();
+                })
                 .onErrorResume(throwable -> {
                     log.warn("Failed to call profiles service (getActiveUsers). Returning empty result. Cause: {}", throwable.toString());
                     return Flux.empty();
@@ -73,6 +109,14 @@ public class ProfilesHttp {
                 .retrieve()
                 .toEntity(SharedProfileDto.class)
                 .map(ResponseEntity::getBody)
+                .timeout(Duration.ofMillis(timeoutMs))
+                .retryWhen(buildRetry("getProfile"))
+                .transformDeferred(BulkheadOperator.of(profilesBulkhead))
+                .transformDeferred(CircuitBreakerOperator.of(profilesCircuitBreaker))
+                .onErrorResume(CallNotPermittedException.class, throwable -> {
+                    log.warn("Profiles circuit breaker open (getProfile {}). Returning empty result.", id);
+                    return Mono.empty();
+                })
                 .onErrorResume(throwable -> {
                     log.warn("Failed to call profiles service (getProfile {}). Cause: {}", id, throwable.toString());
                     return Mono.empty();
@@ -102,9 +146,31 @@ public class ProfilesHttp {
                         .build())
                 .retrieve()
                 .bodyToFlux(SharedProfileDto.class)
+                .timeout(Duration.ofMillis(timeoutMs))
+                .retryWhen(buildRetry("getProfilesByIds"))
+                .transformDeferred(BulkheadOperator.of(profilesBulkhead))
+                .transformDeferred(CircuitBreakerOperator.of(profilesCircuitBreaker))
+                .onErrorResume(CallNotPermittedException.class, throwable -> {
+                    log.warn("Profiles circuit breaker open (getProfilesByIds). Returning empty result.");
+                    return Flux.empty();
+                })
                 .onErrorResume(throwable -> {
                     log.warn("Failed to fetch profiles by IDs: {}", throwable.toString());
                     return Flux.empty();
                 });
+    }
+
+    private Retry buildRetry(String operation) {
+        return Retry.backoff(maxRetries, Duration.ofMillis(retryBackoffMs))
+                .jitter(0.5d)
+                .filter(throwable -> !(throwable instanceof CallNotPermittedException))
+                .doBeforeRetry(retrySignal -> log.warn(
+                        "Retrying profiles service call ({}), attempt {} due to {}",
+                        operation,
+                        retrySignal.totalRetries() + 1,
+                        retrySignal.failure() instanceof TimeoutException
+                                ? "timeout"
+                                : retrySignal.failure().toString()
+                ));
     }
 }

--- a/services/deck/src/main/java/com/tinder/deck/adapters/SwipesHttp.java
+++ b/services/deck/src/main/java/com/tinder/deck/adapters/SwipesHttp.java
@@ -1,20 +1,43 @@
 package com.tinder.deck.adapters;
 
+import io.github.resilience4j.bulkhead.SemaphoreBulkhead;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.reactor.bulkhead.operator.BulkheadOperator;
+import io.github.resilience4j.reactor.circuitbreaker.operator.CircuitBreakerOperator;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeoutException;
 
 @Service
 @RequiredArgsConstructor
 public class SwipesHttp {
+    private static final Logger log = LoggerFactory.getLogger(SwipesHttp.class);
 
     private final WebClient swipesWebClient;
+    private final CircuitBreaker swipesCircuitBreaker;
+    private final SemaphoreBulkhead swipesBulkhead;
+
+    @Value("${deck.clients.swipes.timeout-ms:1500}")
+    private long timeoutMs;
+
+    @Value("${deck.clients.swipes.retry.max-attempts:2}")
+    private int maxRetries;
+
+    @Value("${deck.clients.swipes.retry.backoff-ms:200}")
+    private long retryBackoffMs;
 
     /**
      * Batch check if swipes exist between viewer and candidates
@@ -25,6 +48,32 @@ public class SwipesHttp {
                 .uri("/between/batch?viewerId={id}", viewerId)
                 .bodyValue(candidateIds)
                 .retrieve()
-                .bodyToMono(new ParameterizedTypeReference<Map<UUID, Boolean>>() {});
+                .bodyToMono(new ParameterizedTypeReference<Map<UUID, Boolean>>() {})
+                .timeout(Duration.ofMillis(timeoutMs))
+                .retryWhen(buildRetry())
+                .transformDeferred(BulkheadOperator.of(swipesBulkhead))
+                .transformDeferred(CircuitBreakerOperator.of(swipesCircuitBreaker))
+                .onErrorResume(CallNotPermittedException.class, throwable -> {
+                    log.warn("Swipes circuit breaker open (betweenBatch). Returning empty swipe map.");
+                    return Mono.just(Map.of());
+                })
+                .onErrorResume(throwable -> {
+                    log.warn("Failed to call swipes service (betweenBatch). Returning empty swipe map. Cause: {}",
+                            throwable.toString());
+                    return Mono.just(Map.of());
+                });
+    }
+
+    private Retry buildRetry() {
+        return Retry.backoff(maxRetries, Duration.ofMillis(retryBackoffMs))
+                .jitter(0.5d)
+                .filter(throwable -> !(throwable instanceof CallNotPermittedException))
+                .doBeforeRetry(retrySignal -> log.warn(
+                        "Retrying swipes service call, attempt {} due to {}",
+                        retrySignal.totalRetries() + 1,
+                        retrySignal.failure() instanceof TimeoutException
+                                ? "timeout"
+                                : retrySignal.failure().toString()
+                ));
     }
 }

--- a/services/deck/src/main/java/com/tinder/deck/config/ResilienceConfig.java
+++ b/services/deck/src/main/java/com/tinder/deck/config/ResilienceConfig.java
@@ -1,0 +1,42 @@
+package com.tinder.deck.config;
+
+import io.github.resilience4j.bulkhead.SemaphoreBulkhead;
+import io.github.resilience4j.bulkhead.SemaphoreBulkheadRegistry;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ResilienceConfig {
+
+    @Bean
+    public CircuitBreaker profilesCircuitBreaker(CircuitBreakerRegistry registry) {
+        return registry.circuitBreaker("profilesClient");
+    }
+
+    @Bean
+    public CircuitBreaker swipesCircuitBreaker(CircuitBreakerRegistry registry) {
+        return registry.circuitBreaker("swipesClient");
+    }
+
+    @Bean
+    public CircuitBreaker redisCircuitBreaker(CircuitBreakerRegistry registry) {
+        return registry.circuitBreaker("redisCache");
+    }
+
+    @Bean
+    public SemaphoreBulkhead profilesBulkhead(SemaphoreBulkheadRegistry registry) {
+        return registry.bulkhead("profilesClient");
+    }
+
+    @Bean
+    public SemaphoreBulkhead swipesBulkhead(SemaphoreBulkheadRegistry registry) {
+        return registry.bulkhead("swipesClient");
+    }
+
+    @Bean
+    public SemaphoreBulkhead redisBulkhead(SemaphoreBulkheadRegistry registry) {
+        return registry.bulkhead("redisCache");
+    }
+}

--- a/services/deck/src/main/java/com/tinder/deck/service/DeckCache.java
+++ b/services/deck/src/main/java/com/tinder/deck/service/DeckCache.java
@@ -1,5 +1,10 @@
 package com.tinder.deck.service;
 
+import io.github.resilience4j.bulkhead.SemaphoreBulkhead;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.reactor.bulkhead.operator.BulkheadOperator;
+import io.github.resilience4j.reactor.circuitbreaker.operator.CircuitBreakerOperator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,13 +14,15 @@ import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +30,8 @@ import java.util.regex.Pattern;
 public class DeckCache {
 
     private final ReactiveStringRedisTemplate redis;
+    private final CircuitBreaker redisCircuitBreaker;
+    private final SemaphoreBulkhead redisBulkhead;
 
     // Redis key patterns
     private static String deckKey(UUID id)        { return "deck:" + id; }
@@ -48,6 +57,14 @@ public class DeckCache {
     @Value("${deck.preferences-cache-ttl-minutes:5}")
     private long preferencesCacheTtlMinutes;
 
+    @Value("${deck.redis.timeout-ms:200}")
+    private long redisTimeoutMs;
+
+    @Value("${deck.redis.retry.max-attempts:1}")
+    private int redisMaxRetries;
+
+    @Value("${deck.redis.retry.backoff-ms:50}")
+    private long redisRetryBackoffMs;
 
     public Mono<Void> writeDeck(UUID viewerId, List<Entry<UUID, Double>> deck, Duration ttl) {
         String key   = deckKey(viewerId);
@@ -60,33 +77,36 @@ public class DeckCache {
                 .collect(Collectors.toSet())
                 .flatMap(tuples -> z.addAll(key, tuples));
 
-        return redis.delete(key, tsKey)     // fast delete старых данных
+        Mono<Void> writeFlow = redis.delete(key, tsKey)     // fast delete старых данных
                 .then(addAll)                               // ZADD all
                 .then(redis.expire(key, ttl))               // TTL
                 .then(redis.opsForValue().set(tsKey, String.valueOf(System.currentTimeMillis()))) // TS
                 .then();
+        return withRedisResilience(writeFlow, "writeDeck", Mono.empty());
     }
 
     public Flux<UUID> readDeck(UUID viewerId, int offset, int limit) {
         String key = deckKey(viewerId);
         long end = offset + Math.max(limit, 1) - 1;
-        return redis.opsForZSet()
+        Flux<UUID> readFlow = redis.opsForZSet()
                 .reverseRange(key, org.springframework.data.domain.Range.closed((long)offset, end))
                 .map(UUID::fromString);
+        return withRedisResilience(readFlow, "readDeck");
     }
 
     public Mono<Long> size(UUID viewerId) {
-        return redis.opsForZSet().size(deckKey(viewerId));
+        return withRedisResilience(redis.opsForZSet().size(deckKey(viewerId)), "size", Mono.just(0L));
     }
 
     public Mono<Optional<Instant>> getBuildInstant(UUID viewerId) {
-        return redis.opsForValue().get(deckTsKey(viewerId))
+        Mono<Optional<Instant>> readFlow = redis.opsForValue().get(deckTsKey(viewerId))
                 .map(v -> Optional.of(Instant.ofEpochMilli(Long.parseLong(v))))
                 .defaultIfEmpty(Optional.empty());
+        return withRedisResilience(readFlow, "getBuildInstant", Mono.just(Optional.empty()));
     }
 
     public Mono<Long> invalidate(UUID viewerId) {
-        return redis.delete(deckKey(viewerId), deckTsKey(viewerId));
+        return withRedisResilience(redis.delete(deckKey(viewerId), deckTsKey(viewerId)), "invalidate", Mono.just(0L));
     }
 
     public Mono<List<UUID>> readTop(UUID viewerId, int topN) {
@@ -94,10 +114,11 @@ public class DeckCache {
     }
 
     public Flux<Entry<UUID, Double>> readRangeWithScores(UUID viewerId, long start, long end) {
-        return redis.opsForZSet()
+        Flux<Entry<UUID, Double>> readFlow = redis.opsForZSet()
                 .reverseRangeWithScores(deckKey(viewerId), org.springframework.data.domain.Range.closed(start, end))
                 .map(t -> Map.entry(UUID.fromString(Objects.requireNonNull(t.getValue())),
                         Objects.requireNonNull(t.getScore())));
+        return withRedisResilience(readFlow, "readRangeWithScores");
     }
 
     // ==================== Phase 2: Stale Tracking ====================
@@ -114,9 +135,10 @@ public class DeckCache {
         String key = staleKey(viewerId);
         log.debug("Marking profile {} as stale for viewer {}", profileId, viewerId);
 
-        return redis.opsForSet()
+        Mono<Long> writeFlow = redis.opsForSet()
                 .add(key, profileId.toString())
                 .flatMap(added -> redis.expire(key, DEFAULT_STALE_TTL).thenReturn(added));
+        return withRedisResilience(writeFlow, "markAsStale", Mono.just(0L));
     }
 
     /**
@@ -126,7 +148,8 @@ public class DeckCache {
      * @return Mono<Long> number of decks marked as stale
      */
     public Mono<Long> markAsStaleForAllDecks(UUID profileId) {
-        return redis.keys("deck:*")
+        Flux<String> keyFlow = redis.keys("deck:*");
+        return withRedisResilience(keyFlow, "markAsStaleForAllDecks")
                 .filter(key -> DECK_KEY_PATTERN.matcher(key).matches())
                 .flatMap(key -> {
                     String idPart = key.substring("deck:".length());
@@ -151,8 +174,11 @@ public class DeckCache {
      * @return Mono<Boolean> true if profile is stale
      */
     public Mono<Boolean> isStale(UUID viewerId, UUID profileId) {
-        return redis.opsForSet()
-                .isMember(staleKey(viewerId), profileId.toString());
+        return withRedisResilience(
+                redis.opsForSet().isMember(staleKey(viewerId), profileId.toString()),
+                "isStale",
+                Mono.just(false)
+        );
     }
 
     /**
@@ -162,9 +188,10 @@ public class DeckCache {
      * @return Flux of stale profile IDs
      */
     public Flux<UUID> getStaleProfiles(UUID viewerId) {
-        return redis.opsForSet()
+        Flux<UUID> readFlow = redis.opsForSet()
                 .members(staleKey(viewerId))
                 .map(UUID::fromString);
+        return withRedisResilience(readFlow, "getStaleProfiles");
     }
 
     /**
@@ -175,8 +202,11 @@ public class DeckCache {
      * @return Mono<Long> number of removed items
      */
     public Mono<Long> removeStale(UUID viewerId, UUID profileId) {
-        return redis.opsForSet()
-                .remove(staleKey(viewerId), profileId.toString());
+        return withRedisResilience(
+                redis.opsForSet().remove(staleKey(viewerId), profileId.toString()),
+                "removeStale",
+                Mono.just(0L)
+        );
     }
 
     /**
@@ -186,8 +216,9 @@ public class DeckCache {
      * @return Mono<Boolean> true if stale set was deleted
      */
     public Mono<Boolean> clearStale(UUID viewerId) {
-        return redis.delete(staleKey(viewerId))
+        Mono<Boolean> writeFlow = redis.delete(staleKey(viewerId))
                 .map(count -> count > 0);
+        return withRedisResilience(writeFlow, "clearStale", Mono.just(false));
     }
 
     // ==================== Phase 2: Distributed Locking ====================
@@ -214,7 +245,7 @@ public class DeckCache {
         String key = lockKey(viewerId);
         log.debug("Attempting to acquire lock for viewer {}", viewerId);
 
-        return redis.opsForValue()
+        Mono<Boolean> writeFlow = redis.opsForValue()
                 .setIfAbsent(key, LOCK_VALUE, ttl)
                 .doOnNext(acquired -> {
                     if (acquired) {
@@ -223,6 +254,7 @@ public class DeckCache {
                         log.debug("Lock already held for viewer {}", viewerId);
                     }
                 });
+        return withRedisResilience(writeFlow, "acquireLock", Mono.just(false));
     }
 
     /**
@@ -235,7 +267,7 @@ public class DeckCache {
         String key = lockKey(viewerId);
         log.debug("Releasing lock for viewer {}", viewerId);
 
-        return redis.delete(key)
+        Mono<Boolean> writeFlow = redis.delete(key)
                 .map(count -> count > 0)
                 .doOnNext(released -> {
                     if (released) {
@@ -244,6 +276,7 @@ public class DeckCache {
                         log.warn("No lock found to release for viewer {}", viewerId);
                     }
                 });
+        return withRedisResilience(writeFlow, "releaseLock", Mono.just(false));
     }
 
     /**
@@ -253,7 +286,7 @@ public class DeckCache {
      * @return Mono<Boolean> true if lock exists
      */
     public Mono<Boolean> isLocked(UUID viewerId) {
-        return redis.hasKey(lockKey(viewerId));
+        return withRedisResilience(redis.hasKey(lockKey(viewerId)), "isLocked", Mono.just(false));
     }
 
     /**
@@ -333,8 +366,11 @@ public class DeckCache {
         String key = deckKey(viewerId);
         log.debug("Removing profile {} from deck of viewer {}", profileId, viewerId);
 
-        return redis.opsForZSet()
-                .remove(key, profileId.toString());
+        return withRedisResilience(
+                redis.opsForZSet().remove(key, profileId.toString()),
+                "removeFromDeck",
+                Mono.just(0L)
+        );
     }
 
     /**
@@ -356,8 +392,11 @@ public class DeckCache {
                 .map(UUID::toString)
                 .toArray(String[]::new);
 
-        return redis.opsForZSet()
-                .remove(key, (Object[]) profileStrings);
+        return withRedisResilience(
+                redis.opsForZSet().remove(key, (Object[]) profileStrings),
+                "removeMultipleFromDeck",
+                Mono.just(0L)
+        );
     }
 
     /**
@@ -383,7 +422,11 @@ public class DeckCache {
      * @return Mono<Boolean> true if cached
      */
     public Mono<Boolean> hasPreferencesCache(int minAge, int maxAge, String gender) {
-        return redis.hasKey(preferencesKey(minAge, maxAge, gender));
+        return withRedisResilience(
+                redis.hasKey(preferencesKey(minAge, maxAge, gender)),
+                "hasPreferencesCache",
+                Mono.just(false)
+        );
     }
 
     /**
@@ -398,10 +441,11 @@ public class DeckCache {
         String key = preferencesKey(minAge, maxAge, gender);
         log.debug("Fetching preferences cache: {}", key);
 
-        return redis.opsForSet()
+        Flux<UUID> readFlow = redis.opsForSet()
                 .members(key)
                 .map(UUID::fromString)
                 .doOnComplete(() -> log.debug("Preferences cache HIT: {}", key));
+        return withRedisResilience(readFlow, "getCandidatesByPreferences");
     }
 
     /**
@@ -428,11 +472,12 @@ public class DeckCache {
 
         Duration ttl = Duration.ofMinutes(preferencesCacheTtlMinutes);
 
-        return redis.opsForSet()
+        Mono<Long> writeFlow = redis.opsForSet()
                 .add(key, candidateStrings)
                 .flatMap(count -> redis.expire(key, ttl).thenReturn(count))
                 .doOnSuccess(count -> log.info("Cached {} candidates for preferences {} (TTL: {})",
                         count, key, ttl));
+        return withRedisResilience(writeFlow, "cachePreferencesResult", Mono.just(0L));
     }
 
     /**
@@ -448,7 +493,7 @@ public class DeckCache {
         String key = preferencesKey(minAge, maxAge, gender);
         log.info("Invalidating preferences cache: {}", key);
 
-        return redis.delete(key)
+        Mono<Boolean> writeFlow = redis.delete(key)
                 .map(count -> count > 0)
                 .doOnNext(deleted -> {
                     if (deleted) {
@@ -457,6 +502,7 @@ public class DeckCache {
                         log.debug("Preferences cache not found (already expired?): {}", key);
                     }
                 });
+        return withRedisResilience(writeFlow, "invalidatePreferencesCache", Mono.just(false));
     }
 
     /**
@@ -468,7 +514,56 @@ public class DeckCache {
      * @return Mono<Long> number of candidates in cache
      */
     public Mono<Long> getPreferencesCacheSize(int minAge, int maxAge, String gender) {
-        return redis.opsForSet()
-                .size(preferencesKey(minAge, maxAge, gender));
+        return withRedisResilience(
+                redis.opsForSet().size(preferencesKey(minAge, maxAge, gender)),
+                "getPreferencesCacheSize",
+                Mono.just(0L)
+        );
+    }
+
+    private <T> Mono<T> withRedisResilience(Mono<T> action, String operation, Mono<T> fallback) {
+        return action
+                .timeout(Duration.ofMillis(redisTimeoutMs))
+                .retryWhen(buildRetry(operation))
+                .transformDeferred(BulkheadOperator.of(redisBulkhead))
+                .transformDeferred(CircuitBreakerOperator.of(redisCircuitBreaker))
+                .onErrorResume(CallNotPermittedException.class, throwable -> {
+                    log.warn("Redis circuit breaker open ({}). Skipping cache.", operation);
+                    return fallback;
+                })
+                .onErrorResume(throwable -> {
+                    log.warn("Redis operation failed ({}). Skipping cache. Cause: {}", operation, throwable.toString());
+                    return fallback;
+                });
+    }
+
+    private <T> Flux<T> withRedisResilience(Flux<T> action, String operation) {
+        return action
+                .timeout(Duration.ofMillis(redisTimeoutMs))
+                .retryWhen(buildRetry(operation))
+                .transformDeferred(BulkheadOperator.of(redisBulkhead))
+                .transformDeferred(CircuitBreakerOperator.of(redisCircuitBreaker))
+                .onErrorResume(CallNotPermittedException.class, throwable -> {
+                    log.warn("Redis circuit breaker open ({}). Skipping cache.", operation);
+                    return Flux.empty();
+                })
+                .onErrorResume(throwable -> {
+                    log.warn("Redis operation failed ({}). Skipping cache. Cause: {}", operation, throwable.toString());
+                    return Flux.empty();
+                });
+    }
+
+    private Retry buildRetry(String operation) {
+        return Retry.backoff(redisMaxRetries, Duration.ofMillis(redisRetryBackoffMs))
+                .jitter(0.5d)
+                .filter(throwable -> !(throwable instanceof CallNotPermittedException))
+                .doBeforeRetry(retrySignal -> log.warn(
+                        "Retrying redis operation ({}), attempt {} due to {}",
+                        operation,
+                        retrySignal.totalRetries() + 1,
+                        retrySignal.failure() instanceof TimeoutException
+                                ? "timeout"
+                                : retrySignal.failure().toString()
+                ));
     }
 }

--- a/services/deck/src/main/java/com/tinder/deck/service/pipeline/SwipeFilterStage.java
+++ b/services/deck/src/main/java/com/tinder/deck/service/pipeline/SwipeFilterStage.java
@@ -7,8 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 
-import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -44,9 +42,6 @@ public class SwipeFilterStage extends BasicStage {
                 candidateIds.size(), viewerId);
 
         return swipesHttp.betweenBatch(viewerId, candidateIds)
-                .timeout(Duration.ofMillis(timeoutMs))
-                .retry(retries)
-                .onErrorReturn(Collections.emptyMap())
                 .flatMapMany(swipeMap -> Flux.fromIterable(batch)
                         .filter(candidate -> !hasSwipeHistory(candidate.id(), swipeMap)));
     }

--- a/services/deck/src/main/resources/application.yml
+++ b/services/deck/src/main/resources/application.yml
@@ -128,7 +128,7 @@ resilience4j:
         slowCallDurationThreshold: 1s
       redisCache:
         baseConfig: default
-        slowCallDurationThreshold: 200ms
+        slowCallDurationThreshold: 150ms
   bulkhead:
     instances:
       profilesClient:

--- a/services/deck/src/main/resources/application.yml
+++ b/services/deck/src/main/resources/application.yml
@@ -38,6 +38,22 @@ deck:
   ttl-minutes: 60
   per-user-limit: 500
   search-limit: 2000
+  clients:
+    profiles:
+      timeout-ms: 1500
+      retry:
+        max-attempts: 2
+        backoff-ms: 200
+    swipes:
+      timeout-ms: 1500
+      retry:
+        max-attempts: 2
+        backoff-ms: 200
+  redis:
+    timeout-ms: 200
+    retry:
+      max-attempts: 1
+      backoff-ms: 50
 
   # Preferences Cache Configuration
   # Optimizes batch rebuilds by sharing candidate queries across users with same preferences
@@ -89,3 +105,38 @@ management:
 logging:
   level:
     com.tinder.deck.adapters: DEBUG
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 50
+        minimumNumberOfCalls: 20
+        failureRateThreshold: 50
+        slowCallRateThreshold: 50
+        slowCallDurationThreshold: 2s
+        waitDurationInOpenState: 20s
+        permittedNumberOfCallsInHalfOpenState: 5
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+    instances:
+      profilesClient:
+        baseConfig: default
+        slowCallDurationThreshold: 1s
+      swipesClient:
+        baseConfig: default
+        slowCallDurationThreshold: 1s
+      redisCache:
+        baseConfig: default
+        slowCallDurationThreshold: 200ms
+  bulkhead:
+    instances:
+      profilesClient:
+        maxConcurrentCalls: 40
+        maxWaitDuration: 0
+      swipesClient:
+        maxConcurrentCalls: 30
+        maxWaitDuration: 0
+      redisCache:
+        maxConcurrentCalls: 60
+        maxWaitDuration: 0

--- a/services/deck/src/test/java/com/tinder/deck/adapters/ProfilesHttpCircuitBreakerTest.java
+++ b/services/deck/src/test/java/com/tinder/deck/adapters/ProfilesHttpCircuitBreakerTest.java
@@ -1,0 +1,40 @@
+package com.tinder.deck.adapters;
+
+import io.github.resilience4j.bulkhead.SemaphoreBulkheadRegistry;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class ProfilesHttpCircuitBreakerTest {
+
+    @Test
+    void searchProfilesReturnsEmptyWhenCircuitOpen() {
+        ExchangeFunction exchangeFunction = request -> Mono.just(ClientResponse.create(500).build());
+        WebClient webClient = WebClient.builder().exchangeFunction(exchangeFunction).build();
+
+        CircuitBreakerRegistry cbRegistry = CircuitBreakerRegistry.ofDefaults();
+        SemaphoreBulkheadRegistry bulkheadRegistry = SemaphoreBulkheadRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = cbRegistry.circuitBreaker("profilesClient");
+        circuitBreaker.transitionToOpenState();
+
+        ProfilesHttp client = new ProfilesHttp(
+                webClient,
+                circuitBreaker,
+                bulkheadRegistry.bulkhead("profilesClient")
+        );
+        ReflectionTestUtils.setField(client, "timeoutMs", 10L);
+        ReflectionTestUtils.setField(client, "maxRetries", 0);
+        ReflectionTestUtils.setField(client, "retryBackoffMs", 1L);
+
+        StepVerifier.create(client.searchProfiles(UUID.randomUUID(), null, 5))
+                .expectComplete()
+                .verify();
+    }
+}

--- a/services/deck/src/test/java/com/tinder/deck/adapters/SwipesHttpCircuitBreakerTest.java
+++ b/services/deck/src/test/java/com/tinder/deck/adapters/SwipesHttpCircuitBreakerTest.java
@@ -1,0 +1,42 @@
+package com.tinder.deck.adapters;
+
+import io.github.resilience4j.bulkhead.SemaphoreBulkheadRegistry;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class SwipesHttpCircuitBreakerTest {
+
+    @Test
+    void betweenBatchReturnsEmptyMapWhenCircuitOpen() {
+        ExchangeFunction exchangeFunction = request -> Mono.just(ClientResponse.create(500).build());
+        WebClient webClient = WebClient.builder().exchangeFunction(exchangeFunction).build();
+
+        CircuitBreakerRegistry cbRegistry = CircuitBreakerRegistry.ofDefaults();
+        SemaphoreBulkheadRegistry bulkheadRegistry = SemaphoreBulkheadRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = cbRegistry.circuitBreaker("swipesClient");
+        circuitBreaker.transitionToOpenState();
+
+        SwipesHttp client = new SwipesHttp(
+                webClient,
+                circuitBreaker,
+                bulkheadRegistry.bulkhead("swipesClient")
+        );
+        ReflectionTestUtils.setField(client, "timeoutMs", 10L);
+        ReflectionTestUtils.setField(client, "maxRetries", 0);
+        ReflectionTestUtils.setField(client, "retryBackoffMs", 1L);
+
+        StepVerifier.create(client.betweenBatch(UUID.randomUUID(), List.of(UUID.randomUUID())))
+                .expectNext(Map.of())
+                .verifyComplete();
+    }
+}

--- a/services/deck/src/test/java/com/tinder/deck/service/DeckCacheCircuitBreakerTest.java
+++ b/services/deck/src/test/java/com/tinder/deck/service/DeckCacheCircuitBreakerTest.java
@@ -1,0 +1,40 @@
+package com.tinder.deck.service;
+
+import io.github.resilience4j.bulkhead.SemaphoreBulkheadRegistry;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DeckCacheCircuitBreakerTest {
+
+    @Test
+    void sizeReturnsZeroWhenCircuitOpen() {
+        ReactiveStringRedisTemplate redis = mock(ReactiveStringRedisTemplate.class);
+        when(redis.opsForZSet()).thenThrow(new IllegalStateException("redis should not be called"));
+
+        CircuitBreakerRegistry cbRegistry = CircuitBreakerRegistry.ofDefaults();
+        SemaphoreBulkheadRegistry bulkheadRegistry = SemaphoreBulkheadRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = cbRegistry.circuitBreaker("redisCache");
+        circuitBreaker.transitionToOpenState();
+
+        DeckCache cache = new DeckCache(
+                redis,
+                circuitBreaker,
+                bulkheadRegistry.bulkhead("redisCache")
+        );
+        ReflectionTestUtils.setField(cache, "redisTimeoutMs", 10L);
+        ReflectionTestUtils.setField(cache, "redisMaxRetries", 0);
+        ReflectionTestUtils.setField(cache, "redisRetryBackoffMs", 1L);
+
+        StepVerifier.create(cache.size(UUID.randomUUID()))
+                .expectNext(0L)
+                .verifyComplete();
+    }
+}

--- a/services/profiles/pom.xml
+++ b/services/profiles/pom.xml
@@ -216,6 +216,18 @@
             <artifactId>dotenv-java</artifactId>
             <version>3.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-spring-boot3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-reactor</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-bulkhead</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/services/profiles/src/main/java/com/tinder/profiles/config/ResilienceConfig.java
+++ b/services/profiles/src/main/java/com/tinder/profiles/config/ResilienceConfig.java
@@ -1,0 +1,22 @@
+package com.tinder.profiles.config;
+
+import io.github.resilience4j.bulkhead.SemaphoreBulkhead;
+import io.github.resilience4j.bulkhead.SemaphoreBulkheadRegistry;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ResilienceConfig {
+
+    @Bean
+    public CircuitBreaker nominatimCircuitBreaker(CircuitBreakerRegistry registry) {
+        return registry.circuitBreaker("nominatimClient");
+    }
+
+    @Bean
+    public SemaphoreBulkhead nominatimBulkhead(SemaphoreBulkheadRegistry registry) {
+        return registry.bulkhead("nominatimClient");
+    }
+}

--- a/services/profiles/src/main/resources/application.yml
+++ b/services/profiles/src/main/resources/application.yml
@@ -66,6 +66,7 @@ app:
     country-codes:  "de,at,pl"
     timeout-ms: 5000
     retries: 3
+    retry-backoff-ms: 400
 
 cloud:
   aws:
@@ -88,3 +89,26 @@ kafka:
       updated: profile.updated
       created: profile.created
       deleted: profile.deleted
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 30
+        minimumNumberOfCalls: 10
+        failureRateThreshold: 50
+        slowCallRateThreshold: 50
+        slowCallDurationThreshold: 2s
+        waitDurationInOpenState: 30s
+        permittedNumberOfCallsInHalfOpenState: 5
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+    instances:
+      nominatimClient:
+        baseConfig: default
+        slowCallDurationThreshold: 1500ms
+  bulkhead:
+    instances:
+      nominatimClient:
+        maxConcurrentCalls: 20
+        maxWaitDuration: 0

--- a/services/profiles/src/test/java/com/tinder/profiles/geocoding/NominatimServiceCircuitBreakerTest.java
+++ b/services/profiles/src/test/java/com/tinder/profiles/geocoding/NominatimServiceCircuitBreakerTest.java
@@ -1,0 +1,42 @@
+package com.tinder.profiles.geocoding;
+
+import io.github.resilience4j.bulkhead.SemaphoreBulkheadRegistry;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NominatimServiceCircuitBreakerTest {
+
+    @Test
+    void geocodeCityReturnsEmptyWhenCircuitOpen() {
+        ExchangeFunction exchangeFunction = request -> Mono.just(ClientResponse.create(500).build());
+        WebClient webClient = WebClient.builder().exchangeFunction(exchangeFunction).build();
+
+        CircuitBreakerRegistry cbRegistry = CircuitBreakerRegistry.ofDefaults();
+        SemaphoreBulkheadRegistry bulkheadRegistry = SemaphoreBulkheadRegistry.ofDefaults();
+        CircuitBreaker circuitBreaker = cbRegistry.circuitBreaker("nominatimClient");
+        circuitBreaker.transitionToOpenState();
+
+        NominatimService service = new NominatimService(
+                webClient,
+                circuitBreaker,
+                bulkheadRegistry.bulkhead("nominatimClient")
+        );
+        ReflectionTestUtils.setField(service, "timeoutMs", 10L);
+        ReflectionTestUtils.setField(service, "maxRetries", 0);
+        ReflectionTestUtils.setField(service, "retryBackoffMs", 1L);
+        ReflectionTestUtils.setField(service, "countryCodes", "");
+
+        Optional<NominatimService.GeoPoint> result = service.geocodeCity("Berlin");
+
+        assertTrue(result.isEmpty());
+    }
+}


### PR DESCRIPTION
### Motivation
- Protect user-facing deck flows from cascading failures of remote HTTP dependencies by failing fast and providing safe defaults. 
- Prevent Redis hot-path outages from blocking deck rebuilds or causing slow requests by short-circuiting cache access. 
- Ensure external geocoding (Nominatim) degrades quickly so location creation does not tie up application threads.

### Description
- Added Resilience4j dependencies to `services/deck/pom.xml` and `services/profiles/pom.xml` and registered beans in `services/deck/src/main/java/com/tinder/deck/config/ResilienceConfig.java` and `services/profiles/src/main/java/com/tinder/profiles/config/ResilienceConfig.java`. 
- Wired circuit breakers and semaphore bulkheads into `ProfilesHttp`, `SwipesHttp`, `DeckCache`, and `NominatimService`, and applied `timeout`, bounded `retry` with backoff+jitter, `BulkheadOperator` and `CircuitBreakerOperator`, and explicit open-circuit fallbacks that return safe defaults (empty `Flux`/`Mono`, empty `Map`, zero/false values). 
- Centralized runtime knobs in `application.yml` (`deck.clients.*`, `deck.redis.*`, and `app.geocoding.*`) and added `resilience4j` circuitbreaker/bulkhead instance configs for `profilesClient`, `swipesClient`, `redisCache`, and `nominatimClient`. 
- Added minimal unit tests that assert open-circuit fallback behavior: `services/deck/src/test/java/com/tinder/deck/adapters/ProfilesHttpCircuitBreakerTest.java`, `services/deck/src/test/java/com/tinder/deck/adapters/SwipesHttpCircuitBreakerTest.java`, `services/deck/src/test/java/com/tinder/deck/service/DeckCacheCircuitBreakerTest.java`, and `services/profiles/src/test/java/com/tinder/profiles/geocoding/NominatimServiceCircuitBreakerTest.java`.

### Testing
- Added four minimal automated unit tests targeting open-circuit fallbacks: `ProfilesHttpCircuitBreakerTest`, `SwipesHttpCircuitBreakerTest`, `DeckCacheCircuitBreakerTest`, and `NominatimServiceCircuitBreakerTest`. 
- No automated test suite was executed as part of this change (`mvn test` / CI were not run). 
- Tests are intentionally small and focused on verifying that when a `CircuitBreaker` is transitioned to open the corresponding client/wrapper returns the expected safe default rather than propagating errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69813020b9a8832fab520ba6e38f416a)